### PR TITLE
Prevent type error when response of a request is empty (e.g. internet connection failure)

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,7 +257,7 @@ var options = {
 api.setThermpoint();
 ```
 
-Catching Errors
+Catching Errors and Warnings
 ---
 
 ```javascript
@@ -275,6 +275,11 @@ var api = new netatmo(auth);
 api.on("error", function(error) {
     // When the "error" event is emitted, this is called
     console.error('Netatmo threw an error: ' + error);
+});
+
+api.on("warning", function(error) {
+    // When the "warning" event is emitted, this is called
+    console.log('Netatmo threw a warning: ' + error);
 });
 
 // Rest of program

--- a/netatmo.js
+++ b/netatmo.js
@@ -330,7 +330,9 @@ netatmo.prototype.getMeasure = function(options, callback) {
   }, function(err, response, body) {
     if (err || response.statusCode != 200) {
       var error = this.handleRequestError(err,response,body,"getMeasure error");
-      if (callback) callback(error);
+      if (callback) {
+        callback(error);
+      }
       return;
     }
 

--- a/netatmo.js
+++ b/netatmo.js
@@ -19,6 +19,26 @@ var netatmo = function(args) {
 
 util.inherits(netatmo, EventEmitter);
 
+netatmo.prototype.handleRequestError = function(err,response,body,message,emit) {
+  var errorMessage = "";
+  if (body) {
+    errorMessage = JSON.parse(body);
+    errorMessage = errorMessage && errorMessage.error;
+  } else if (typeof response !== 'undefined') {
+    errorMessage = "Status code" + response.statusCode;
+  }
+  else {
+    errorMessage = "No response";
+  }
+  var error = new Error(message + ": " + errorMessage);
+  if(emit) {
+    this.emit("error", error);
+  } else {
+    console.log(error);
+  }
+  return error;
+};
+
 // http://dev.netatmo.com/doc/authentication
 netatmo.prototype.authenticate = function(args, callback) {
   if (!args) {
@@ -69,15 +89,7 @@ netatmo.prototype.authenticate = function(args, callback) {
     form: form,
   }, function(err, response, body) {
     if (err || response.statusCode != 200) {
-
-      if (body) {
-        var errorMsg = JSON.parse(body);
-        errorMsg = errorMsg && errorMsg.error;
-        this.emit("error", new Error("Authenticate error: " + errorMsg));
-      } else {
-        this.emit("error", new Error("Authenticate error: " + response.statusCode));
-      }
-      return this;
+      return this.handleRequestError(err,response,body,"Authenticate error", true);
     }
 
     body = JSON.parse(body);
@@ -118,14 +130,7 @@ netatmo.prototype.authenticate_refresh = function(refresh_token) {
     form: form,
   }, function(err, response, body) {
     if (err || response.statusCode != 200) {
-
-      if (body) {
-        var errorMsg = JSON.parse(body);
-        errorMsg = errorMsg && errorMsg.error;
-        this.emit("error", new Error("Authenticate refresh error: " + errorMsg));
-      } else {
-        this.emit("error", new Error("Authenticate refresh error: " + response.statusCode));
-      }
+      return this.handleRequestError(err,response,body,"Authenticate refresh error");
     }
 
     body = JSON.parse(body);
@@ -163,8 +168,7 @@ netatmo.prototype.getUser = function(callback) {
     form: form,
   }, function(err, response, body) {
     if (err || response.statusCode != 200) {
-      this.emit("error", new Error("getUser error: " + response.statusCode));
-      return this;
+      return this.handleRequestError(err,response,body,"getUser error");
     }
 
     body = JSON.parse(body);
@@ -212,9 +216,7 @@ netatmo.prototype.getDevicelist = function(options, callback) {
     form: form,
   }, function(err, response, body) {
     if (err || response.statusCode != 200) {
-      console.log(body);
-      this.emit("error", new Error("getDevicelist error: " + response.statusCode));
-      return this;
+      return this.handleRequestError(err,response,body,"getDevicelist error");
     }
 
     body = JSON.parse(body);
@@ -327,9 +329,9 @@ netatmo.prototype.getMeasure = function(options, callback) {
     form: form,
   }, function(err, response, body) {
     if (err || response.statusCode != 200) {
-      console.log(body);
-      this.emit("error", new Error("getMeasure error: " + response.statusCode));
-      return this;
+      var error = this.handleRequestError(err,response,body,"getMeasure error");
+      if (callback) callback(error);
+      return;
     }
 
     body = JSON.parse(body);
@@ -387,9 +389,7 @@ netatmo.prototype.getThermstate = function(options, callback) {
     form: form,
   }, function(err, response, body) {
     if (err || response.statusCode != 200) {
-      console.log(body);
-      this.emit("error", new Error("getThermstate error: " + response.statusCode));
-      return this;
+      return this.handleRequestError(err,response,body,"getThermstate error");
     }
 
     body = JSON.parse(body);
@@ -457,9 +457,7 @@ netatmo.prototype.setSyncSchedule = function(options, callback) {
     form: form,
   }, function(err, response, body) {
     if (err || response.statusCode != 200) {
-      console.log(body);
-      this.emit("error", new Error("setSyncSchedule error: " + response.statusCode));
-      return this;
+      return this.handleRequestError(err,response,body,"setSyncSchedule error");
     }
 
     body = JSON.parse(body);
@@ -533,9 +531,7 @@ netatmo.prototype.setThermpoint = function(options, callback) {
     form: form,
   }, function(err, response, body) {
     if (err || response.statusCode != 200) {
-      console.log(body);
-      this.emit("error", new Error("setThermpoint error: " + response.statusCode));
-      return this;
+      return this.handleRequestError(err,response,body,"setThermpoint error");
     }
 
     body = JSON.parse(body);

--- a/netatmo.js
+++ b/netatmo.js
@@ -19,7 +19,7 @@ var netatmo = function(args) {
 
 util.inherits(netatmo, EventEmitter);
 
-netatmo.prototype.handleRequestError = function(err,response,body,message,emit) {
+netatmo.prototype.handleRequestError = function(err,response,body,message,critical) {
   var errorMessage = "";
   if (body) {
     errorMessage = JSON.parse(body);
@@ -31,10 +31,10 @@ netatmo.prototype.handleRequestError = function(err,response,body,message,emit) 
     errorMessage = "No response";
   }
   var error = new Error(message + ": " + errorMessage);
-  if(emit) {
+  if(critical) {
     this.emit("error", error);
   } else {
-    console.log(error);
+    this.emit("warning", error);
   }
   return error;
 };
@@ -97,7 +97,7 @@ netatmo.prototype.authenticate = function(args, callback) {
     access_token = body.access_token;
 
     if (body.expires_in) {
-        setTimeout(this.authenticate_refresh.bind(this), body.expires_in * 1000, body.refresh_token);
+      setTimeout(this.authenticate_refresh.bind(this), body.expires_in * 1000, body.refresh_token);
     }
 
     this.emit('authenticated');


### PR DESCRIPTION
This is a fix for the following issue: https://github.com/karbassi/netatmo/issues/4

This pull request also improves error events by emitting non-critical errors as a "warning"-event instead of an "error"-event which has a more appropriate default behavior (fails silently, without crashing the app). The error is also returned to callback function as first parameter (according to error-first paradigm; previously no callback was invoked).