### PR TITLE
Prevent a crash when netatmo error body contains HTML and not JSON

### DIFF
--- a/netatmo.js
+++ b/netatmo.js
@@ -22,8 +22,7 @@ util.inherits(netatmo, EventEmitter);
 netatmo.prototype.handleRequestError = function(err,response,body,message,critical) {
   var errorMessage = "";
   if (body) {
-    errorMessage = JSON.parse(body);
-    errorMessage = errorMessage && errorMessage.error;
+    errorMessage = body;
   } else if (typeof response !== 'undefined') {
     errorMessage = "Status code" + response.statusCode;
   }


### PR DESCRIPTION
I had to make another small change.

Sometimes netatmo fails to return JSON when an error occurs. Previously this caused the package to crash. The change should remedy this.