### PR TITLE
use error-message instead of error-object

### DIFF
--- a/netatmo.js
+++ b/netatmo.js
@@ -23,7 +23,7 @@ netatmo.prototype.handleRequestError = function(err,response,body,message,critic
   var errorMessage = "";
   if (body) {
     errorMessage = JSON.parse(body);
-    errorMessage = errorMessage && errorMessage.error;
+    errorMessage = errorMessage && errorMessage.error.message;
   } else if (typeof response !== 'undefined') {
     errorMessage = "Status code" + response.statusCode;
   }

--- a/netatmo.js
+++ b/netatmo.js
@@ -23,7 +23,7 @@ netatmo.prototype.handleRequestError = function(err,response,body,message,critic
   var errorMessage = "";
   if (body) {
     errorMessage = JSON.parse(body);
-    errorMessage = errorMessage && errorMessage.error.message;
+    errorMessage = errorMessage && (errorMessage.error.message || errorMessage.error);
   } else if (typeof response !== 'undefined') {
     errorMessage = "Status code" + response.statusCode;
   }


### PR DESCRIPTION
A little fix for a correct error-message:
before: getMeasure error: [object Object]
now: getMeasure error: Device not found