### PR TITLE
parse body only when content-type is 'application/json'

### DIFF
--- a/netatmo.js
+++ b/netatmo.js
@@ -34,7 +34,7 @@ util.inherits(netatmo, EventEmitter);
  */
 netatmo.prototype.handleRequestError = function (err, response, body, message, critical) {
   var errorMessage = "";
-  if (body) {
+  if (body && response.headers['content-type'] === 'application/json') {
     errorMessage = JSON.parse(body);
     errorMessage = errorMessage && (errorMessage.error.message || errorMessage.error);
   } else if (typeof response !== 'undefined') {


### PR DESCRIPTION
I have another fix for you. Problem: under certain circumstances the authenticate_refresh-function received an non-json-body. In that case the JSON.parse in handleRequestError throws an exception which meant that my program (node-red) was terminated.
Before parsing the body I check the content-type of the response-header. JSON.parse will only called when content-type is 'application/json'. I hope that will fix my problem (I can't test it really good because this problem occurs very rarely).

