### PR TITLE
Allow access token to be provided in the constructor.

### DIFF
--- a/netatmo.js
+++ b/netatmo.js
@@ -64,6 +64,11 @@ netatmo.prototype.authenticate = function (args, callback) {
     return this;
   }
 
+  if (args.access_token) {
+    access_token = args.access_token;
+    return this;
+  }
+
   if (!args.client_id) {
     this.emit("error", new Error("Authenticate 'client_id' not set."));
     return this;


### PR DESCRIPTION
This allows us to do authentication externally via OAuth and pass the access token in to the module.